### PR TITLE
Added .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+# Use the Microsoft style in this project.
+BasedOnStyle: Microsoft
+Language: Cpp


### PR DESCRIPTION
Added clang format file. 

You can create your own formatting using https://zed0.co.uk/clang-format-configurator/

The idea is that you can configure your editor to run clang-format or you can run it manually to keep unified style. https://learn.adafruit.com/the-well-automated-arduino-library/formatting-with-clang-format

No rush to merge this PR. First it's better to fix the build issues. Later on you can play with clang-format